### PR TITLE
fix(drum kit): Update comments and rework main queryselector

### DIFF
--- a/01 - JavaScript Drum Kit/index.html
+++ b/01 - JavaScript Drum Kit/index.html
@@ -59,31 +59,33 @@
 
 <script>
   /**
-   * Class name to be applied to active key nodes.
+   * Class name to be applied to active keyboard input elements.
    */
-  const activeAudioClassName = 'playing';
+  const activeKeyboardInputClassName = 'playing';
   /**
-   * Map of audio sounds and key codes.
+   * Map of audio sounds and keyboard input codes.
    */
   let audioList = {};
   /**
-   * For each audio sound, cache the associated document node (key)
-   * and listen for playback events, then add the sound to our
-   * audio list.
+   * For each keyboard input element, we'll want to query for the matching audio
+   * sound and subscribe to specific playback events. This allows us to add "active"
+   * input element classes and replay the audio on repetitive dispatches.
+   *
+   * 1. Find, listen to, and cache the associated audio sound.
+   * 2. Remove the key node active class once the CSS tranform has completed.
    */
-  Array.from(document.querySelectorAll('audio')).forEach(audio => {
-    const node = document.querySelector(`div[data-key="${audio.dataset.key}"]`);
-    audio.addEventListener('playing', () => node.classList.add(activeAudioClassName), true);
+  Array.from(document.querySelectorAll('.key')).forEach(node => {
+    /* [1] */
+    const audio = document.querySelector(`audio[data-key="${node.dataset.key}"]`);
+    audio.addEventListener('playing', () => node.classList.add(activeKeyboardInputClassName), true);
     audio.addEventListener('replay', () => (audio.currentTime = 0) || audio.play(), true);
     audioList[audio.dataset.key] = audio;
-    /**
-     * Remove the node active class name once the CSS tranform has completed.
-     */
-    node.addEventListener('transitionend', event => event.propertyName === 'transform' && node.classList.remove(activeAudioClassName));
+    /* [2] */
+    node.addEventListener('transitionend', event => event.propertyName === 'transform' && node.classList.remove(activeKeyboardInputClassName));
   });
   /**
    * When a key is pressed, check to see if it's supported in our
-   * audio list, and if it is, replay the audio track.
+   * audio list. If the keyboard input is supported, replay the audio track.
    */
   document.addEventListener('keydown', (event) => {
     if (event.keyCode in audioList) {


### PR DESCRIPTION
Wanted to reverse the main query selector to iterate over the keyboard input elements rather then the audio files. I felt this was more appropriate since the users interact with the `kbd` nodes rather than the audio sounds.